### PR TITLE
doc: add non-default ns secrets guide

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "1.16.0"
 dependencies:
 - name: diagrid-dapr-injector
   version: 1.0.0
-  repository: file://../diagrid-dapr-injector
+  repository: oci://public.ecr.aws/diagrid/d3e-charts
   alias: diagrid_dapr_injector
 - name: redis
   version: 20.11.3

--- a/README.md
+++ b/README.md
@@ -162,6 +162,11 @@ After configuring name resolution, you need to define the necessary services usi
 
 Replace APP_ID with the appropriate application ID. This ensures that Dapr can correctly resolve and communicate with the injected services.
 
+#### Kubernetes permissions in Non-Default Dapr namespaces
+
+If your Dapr enabled apps are using components that fetch secrets from non-default namespaces, please follow this guide [here](https://docs.dapr.io/operations/components/component-secrets/#non-default-namespaces)
+
+
 ### Trust Anchors
 
 Trust anchors are essential for verifying the authenticity of the Dapr control plane.


### PR DESCRIPTION
Update docs with "Kubernetes permissions in Non-Default Dapr namespaces"