### PR TITLE
Sentry ksa automount example

### DIFF
--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -70,6 +70,54 @@ jobs:
         run: |
           make nuke
 
+  standalone-no-crds-automount-sentry-disabled:
+    needs: dependencies
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Make Infra
+        run: |
+          make infra
+      - name: Make d3e standalone with Sentry automount disabled
+        run: |
+          make d3e-standalone-sentry-automount-disabled
+      - name: Make Sample
+        run: |
+          make sample
+      - name: Wait for 1 minute to let the sample app start
+        run: |
+          sleep 60
+      - name: Check pods are ready
+        run: |
+          kubectl wait --for=condition=Ready pods --all --namespace=d3e-sample --timeout=500s
+      - name: Ensure no CRDs exist
+        run: |
+          if kubectl get crds -o name | grep -q .; then
+            echo "CRDs found:"
+            kubectl get crds
+            exit 1
+          else
+            echo "✅ No CRDs found"
+          fi
+      - name: Ensure no ClusterRoles with 'dapr' in the name exist
+        run: |
+          if kubectl get clusterroles -o name | grep -q dapr; then
+            echo "❌ Dapr ClusterRoles found:"
+            kubectl get clusterroles | grep dapr
+            exit 1
+          else
+            echo "✅ No Dapr ClusterRoles found"
+          fi
+      - name: Show all pods
+        if: always()
+        run: |
+          kubectl get pods --all-namespaces
+      - name: Nuke resources 
+        if: always()
+        run: |
+          make nuke
+
   d3e-with-crds-no-cluster-roles:
     needs: dependencies
     runs-on: ubuntu-latest

--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -8,42 +8,69 @@ on:
   pull_request:
 
 jobs:
-  dependencies:
+  test:
+    name: ${{ matrix.name }}
     runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Install kind
-        run: |
-            curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
-            chmod +x ./kind
-            sudo mv ./kind /usr/local/bin/kind
-      - name: Install Helm
-        run: |
-            curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+    
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: Standalone - No CRDs
+            d3e_target: d3e-standalone
+            sample_target: sample
+            check_crds: true
+            check_cluster_roles: true
 
-  standalone-no-crds:
-    needs: dependencies
-    runs-on: ubuntu-latest
+          - name: Standalone - Sentry Disabled
+            d3e_target: d3e-standalone-sentry-automount-disabled
+            sample_target: sample
+            check_crds: true
+            check_cluster_roles: true
+
+          - name: With CRDs - No ClusterRoles
+            d3e_target: d3e-with-crds-no-cluster-roles
+            sample_target: sample-with-crds-no-cluster-roles
+            check_crds: false
+            check_cluster_roles: true
+            
+          - name: Minimal
+            d3e_target: d3e-minimal
+            sample_target: sample-minimal
+            check_crds: false
+            check_cluster_roles: false
+
     steps:
-      - name: Checkout code
+      - name:  checkout code
         uses: actions/checkout@v4
+
+      - name: Install Dependencies (kind & Helm)
+        run: |
+          echo "Installing kind..."
+          curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.23.0/kind-linux-amd64
+          chmod +x ./kind
+          sudo mv ./kind /usr/local/bin/kind
+          echo "Installing Helm..."
+          curl -fsSL https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+
       - name: Make Infra
-        run: |
-          make infra
-      - name: Make d3e Standalone
-        run: |
-          make d3e-standalone
-      - name: Make Sample
-        run: |
-          make sample
-      - name: Wait for 1 minute to let the sample app start
-        run: |
-          sleep 60
+        run: make infra
+
+      - name: Deploy Application
+        run: make ${{ matrix.d3e_target }}
+
+      - name: Deploy Sample
+        run: make ${{ matrix.sample_target }}
+
+      - name: Wait for sample app to start
+        run: sleep 60
+
       - name: Check pods are ready
         run: |
           kubectl wait --for=condition=Ready pods --all --namespace=d3e-sample --timeout=500s
+
       - name: Ensure no CRDs exist
+        if: matrix.check_crds
         run: |
           if kubectl get crds -o name | grep -q .; then
             echo "CRDs found:"
@@ -52,7 +79,9 @@ jobs:
           else
             echo "✅ No CRDs found"
           fi
-      - name: Ensure no ClusterRoles with 'dapr' in the name exist
+
+      - name: Ensure no Dapr ClusterRoles exist
+        if: matrix.check_cluster_roles
         run: |
           if kubectl get clusterroles -o name | grep -q dapr; then
             echo "❌ Dapr ClusterRoles found:"
@@ -63,126 +92,7 @@ jobs:
           fi
       - name: Show all pods
         if: always()
-        run: |
-          kubectl get pods --all-namespaces
+        run: kubectl get pods --all-namespaces
       - name: Nuke resources 
         if: always()
-        run: |
-          make nuke
-
-  standalone-no-crds-automount-sentry-disabled:
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Make Infra
-        run: |
-          make infra
-      - name: Make d3e standalone with Sentry automount disabled
-        run: |
-          make d3e-standalone-sentry-automount-disabled
-      - name: Make Sample
-        run: |
-          make sample
-      - name: Wait for 1 minute to let the sample app start
-        run: |
-          sleep 60
-      - name: Check pods are ready
-        run: |
-          kubectl wait --for=condition=Ready pods --all --namespace=d3e-sample --timeout=500s
-      - name: Ensure no CRDs exist
-        run: |
-          if kubectl get crds -o name | grep -q .; then
-            echo "CRDs found:"
-            kubectl get crds
-            exit 1
-          else
-            echo "✅ No CRDs found"
-          fi
-      - name: Ensure no ClusterRoles with 'dapr' in the name exist
-        run: |
-          if kubectl get clusterroles -o name | grep -q dapr; then
-            echo "❌ Dapr ClusterRoles found:"
-            kubectl get clusterroles | grep dapr
-            exit 1
-          else
-            echo "✅ No Dapr ClusterRoles found"
-          fi
-      - name: Show all pods
-        if: always()
-        run: |
-          kubectl get pods --all-namespaces
-      - name: Nuke resources 
-        if: always()
-        run: |
-          make nuke
-
-  d3e-with-crds-no-cluster-roles:
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Make Infra
-        run: |
-          make infra
-      - name: Make d3e with CRDs and no cluster roles
-        run: |
-          make d3e-with-crds-no-cluster-roles
-      - name: Make Sample with CRDs and no cluster roles
-        run: |
-          make sample-with-crds-no-cluster-roles
-      - name: Wait for 1 minute to let the sample app start
-        run: |
-          sleep 60
-      - name: Check pods are ready
-        run: |
-          kubectl wait --for=condition=Ready pods --all --namespace=d3e-sample --timeout=500s
-      - name: Ensure no ClusterRoles with 'dapr' in the name exist
-        run: |
-          if kubectl get clusterroles -o name | grep -q dapr; then
-            echo "❌ Dapr ClusterRoles found:"
-            kubectl get clusterroles | grep dapr
-            exit 1
-          else
-            echo "✅ No Dapr ClusterRoles found"
-          fi
-      - name: Show all pods
-        if: always()
-        run: |
-          kubectl get pods --all-namespaces
-      - name: Nuke resources 
-        if: always()
-        run: |
-          make nuke
-
-  minimal:
-    needs: dependencies
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
-      - name: Make Infra
-        run: |
-          make infra
-      - name: Make d3e Minimal
-        run: |
-          make d3e-minimal
-      - name: Make Sample Minimal
-        run: |
-          make sample-minimal
-      - name: Wait for 1 minute to let the sample app start
-        run: |
-          sleep 60
-      - name: Check pods are ready
-        run: |
-          kubectl wait --for=condition=Ready pods --all --namespace=d3e-sample --timeout=500s
-      - name: Show all pods
-        if: always()
-        run: |
-          kubectl get pods --all-namespaces
-      - name: Nuke resources 
-        if: always()
-        run: |
-          make nuke
+        run: make nuke

--- a/.github/workflows/global-ci.yaml
+++ b/.github/workflows/global-ci.yaml
@@ -22,7 +22,7 @@ jobs:
             check_crds: true
             check_cluster_roles: true
 
-          - name: Standalone - Sentry Disabled
+          - name: Standalone -  No CRDs & Sentry Automount Disabled
             d3e_target: d3e-standalone-sentry-automount-disabled
             sample_target: sample
             check_crds: true

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ d3e-standalone:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 # This is the standalone d3e deployment with Sentry automountServiceAccountToken disabled.
 d3e-standalone-sentry-automount-disabled:
@@ -46,7 +46,7 @@ d3e-standalone-sentry-automount-disabled:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version v1.15.6-d3e.1
 
 # D3E minimal uses CRDs and minimal cluster roles
 d3e-minimal:
@@ -54,14 +54,14 @@ d3e-minimal:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/minimal-with-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 d3e-with-crds-no-cluster-roles:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/d3e-with-crds-no-cluster-roles.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 uninstall:
 	make uninstall-d3e

--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ d3e-standalone:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 # This is the standalone d3e deployment with Sentry automountServiceAccountToken disabled.
 d3e-standalone-sentry-automount-disabled:
@@ -54,14 +54,14 @@ d3e-minimal:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/minimal-with-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 d3e-with-crds-no-cluster-roles:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/d3e-with-crds-no-cluster-roles.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 uninstall:
 	make uninstall-d3e

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ d3e-standalone-sentry-automount-disabled:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version v1.15.6-d3e.1
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 # D3E minimal uses CRDs and minimal cluster roles
 d3e-minimal:

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,15 @@ d3e-standalone:
 		-f d3e-configs/standalone-no-crds.yaml \
 		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
 
+# This is the standalone d3e deployment with Sentry automountServiceAccountToken disabled.
+d3e-standalone-sentry-automount-disabled:
+	helm install \
+		--skip-crds \
+		--create-namespace \
+		-n d3e-sample \
+		-f d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml \
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+
 # D3E minimal uses CRDs and minimal cluster roles
 d3e-minimal:
 	helm install \

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In your `values.yaml` file, add any necessary overrides for the injector:
 ```yaml
 dapr:  
   image: 
-    tag: "1.15.5"
+    tag: "1.15.6"
   ha:
     enabled: true
   controlPlaneNamespace: dapr-system

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ In your `values.yaml` file, add any necessary overrides for the injector:
 ```yaml
 dapr:  
   image: 
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
   ha:
     enabled: true
   controlPlaneNamespace: dapr-system

--- a/SAMPLE.md
+++ b/SAMPLE.md
@@ -224,7 +224,7 @@ Key configuration points:
 # D3E Control Plane Configuration
 dapr:
   image:
-    tag: "1.15.5"
+    tag: "1.15.6"
   controlPlaneNamespace: "d3e-sample"
 
 # Publisher Service Annotations

--- a/SAMPLE.md
+++ b/SAMPLE.md
@@ -224,7 +224,7 @@ Key configuration points:
 # D3E Control Plane Configuration
 dapr:
   image:
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
   controlPlaneNamespace: "d3e-sample"
 
 # Publisher Service Annotations

--- a/d3e-configs/README.md
+++ b/d3e-configs/README.md
@@ -25,8 +25,24 @@ helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
   -n d3e-sample \
   -f d3e-configs/minimal-with-crds.yaml
 ```
+### 2. `d3e-standalone-no-crds-automount-sentry-disabled.yaml` - Standalone Mode with Secure Sentry
+Use case: Highly restricted environments where you need to explicitly control the ServiceAccount token lifecycle for the Sentry component.
 
-### 2. `standalone-no-crds.yaml` - Standalone Mode without CRDs
+Features:
+
+- ✅ Namespaced RBAC only
+- ✅ No CRDs required
+- ✅ Standalone mode for all components
+- ✅ Secure Sentry with disabled ServiceAccount token automount
+- ✅ Ideal for production or multi-tenant environments requiring explicit security controls.
+
+**Requirements**:
+- Namespace-level permissions only
+- No cluster-admin privileges needed
+- Dapr sentry api access credentials have to be manually mounted.
+
+
+### 3. `standalone-no-crds.yaml` - Standalone Mode without CRDs
 **Use case**: Restricted environments, multi-tenant clusters, or when you don't have cluster-admin privileges.
 
 **Features**:
@@ -71,15 +87,17 @@ helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
 
 ## Configuration Comparison
 
-| Feature | minimal-with-crds | standalone-no-crds | d3e-with-crds-no-cluster-roles |
-|---------|------------------|-------------------|--------------------------------|
-| Cluster Roles | ✅ | ❌ | ❌ |
-| CRDs | ✅ | ❌ | ✅ |
-| Cluster Permissions | Required | Not Required | Required to install CRDs only|
-| Dapr Operator | ✅ | ❌ | ✅ |
-| Sidecar Injector | ✅ | ❌ | ✅ |
-| Standalone Mode | ❌ | ✅ | ❌ |
-| Multi-tenant Safe | ❌ | ✅ | ⚠️ |
+| Feature                   | minimal-with-crds | standalone-no-crds | standalone-no-crds-automount-disabled | d3e-with-crds-no-cluster-roles |
+|---------------------------|-------------------|--------------------|---------------------------------------|--------------------------------|
+| Cluster Roles             | ✅                 | ❌                  | ❌                                     | ❌                              |
+| CRDs                      | ✅                 | ❌                  | ❌                                     | ✅                              |
+| Cluster Permissions       | Required          | Not Required       | Not Required                          | Required to install CRDs only  |
+| Dapr Operator             | ✅                 | ❌                  | ❌                                     | ✅                              |
+| Sidecar Injector          | ✅                 | ❌                  | ❌                                     | ✅                              |
+| Standalone Mode           | ❌                 | ✅                  | ✅                                     | ❌                              |
+| Multi-tenant Safe         | ❌                 | ✅                  | ✅                                     | ⚠️                             |
+| Sentry Automount Disabled | ❌                 | ❌                  | ✅                                     | ❌                              |
+
 
 ## Usage Instructions
 
@@ -108,6 +126,13 @@ d3e-standalone:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds.yaml \
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+
+d3e-standalone-sentry-automount-disabled:
+	helm install \
+		--create-namespace \
+		-n d3e-sample \
+		-f d3e-configs/standalone-no-crds-automount-sentry-disabled \
 		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
 
 d3e-hybrid:

--- a/d3e-configs/README.md
+++ b/d3e-configs/README.md
@@ -20,7 +20,7 @@ This directory contains template values files for different D3E deployment confi
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.6 \
+  --version 1.15.6-d3e.1 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/minimal-with-crds.yaml
@@ -58,7 +58,7 @@ Features:
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.6 \
+  --version 1.15.6-d3e.1 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/standalone-no-crds.yaml
@@ -79,7 +79,7 @@ helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.6 \
+  --version 1.15.6-d3e.1 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -119,28 +119,28 @@ d3e-minimal:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/minimal-with-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 d3e-standalone:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 d3e-standalone-sentry-automount-disabled:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds-automount-sentry-disabled \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 
 d3e-hybrid:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/d3e-with-crds-no-cluster-roles.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6-d3e.1
 ```
 
 ## Key Differences Explained

--- a/d3e-configs/README.md
+++ b/d3e-configs/README.md
@@ -20,7 +20,7 @@ This directory contains template values files for different D3E deployment confi
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.5 \
+  --version 1.15.6 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/minimal-with-crds.yaml
@@ -58,7 +58,7 @@ Features:
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.5 \
+  --version 1.15.6 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/standalone-no-crds.yaml
@@ -79,7 +79,7 @@ helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
 **Command**:
 ```bash
 helm install dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr \
-  --version 1.15.5 \
+  --version 1.15.6 \
   --create-namespace \
   -n d3e-sample \
   -f d3e-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -119,28 +119,28 @@ d3e-minimal:
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/minimal-with-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 d3e-standalone:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 d3e-standalone-sentry-automount-disabled:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/standalone-no-crds-automount-sentry-disabled \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 
 d3e-hybrid:
 	helm install \
 		--create-namespace \
 		-n d3e-sample \
 		-f d3e-configs/d3e-with-crds-no-cluster-roles.yaml \
-		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.5
+		dapr oci://public.ecr.aws/diagrid/d3e-charts/d3e-dapr --version 1.15.6
 ```
 
 ## Key Differences Explained

--- a/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
+++ b/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -29,12 +29,6 @@ dapr_operator:
 dapr_sidecar_injector:
   enabled: false
 
-dapr_placement:
-  mode: "kubernetes"
-
-dapr_scheduler:
-  mode: "kubernetes"
-
 dapr_sentry:
   mode: "standalone"
   injectDaprSystemConfig: true

--- a/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
+++ b/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -4,7 +4,7 @@
 # Note: This may not work in all environments due to CRD cluster-scoping
 
 global:
-  tag: "1.15.6"
+  tag: "1.15.6-d3e.1"
   mtls:
     enabled: true
   actors:

--- a/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
+++ b/d3e-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -4,7 +4,7 @@
 # Note: This may not work in all environments due to CRD cluster-scoping
 
 global:
-  tag: "1.15.5"
+  tag: "1.15.6"
   mtls:
     enabled: true
   actors:

--- a/d3e-configs/minimal-with-crds.yaml
+++ b/d3e-configs/minimal-with-crds.yaml
@@ -4,7 +4,7 @@
 
 # Global settings
 global:
-  tag: "1.15.5"
+  tag: "1.15.6"
   mtls:
     enabled: true
   actors:

--- a/d3e-configs/minimal-with-crds.yaml
+++ b/d3e-configs/minimal-with-crds.yaml
@@ -4,7 +4,7 @@
 
 # Global settings
 global:
-  tag: "1.15.6"
+  tag: "1.15.6-d3e.1"
   mtls:
     enabled: true
   actors:

--- a/d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml
+++ b/d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml
@@ -1,0 +1,65 @@
+# Standalone D3E Configuration without CRDs and with Sentry Automount Disabled
+# This configuration uses namespaced RBAC and standalone mode
+# No cluster-wide permissions required - perfect for restricted environments
+# This is the configuration currently used in the Makefile
+
+global:
+  tag: "1.15.5"
+  mtls:
+    enabled: true
+  actors:
+    enabled: false
+  scheduler:
+    enabled: false
+  rbac:
+    namespaced: true 
+    namespaces: ["d3e-sample"]
+    injector:
+      enabled: false
+    operator:
+      enabled: false
+    crds:
+      enabled: false
+
+    createTokenReviewerRole: false
+    createTokenReviewerRoleBinding: false
+    sentry:
+      serviceAccount: 
+        create: true
+        automount: false
+
+# These mounts are required when service account automount is disabled for sentry to access the Kubernetes API
+  extraVolumeMounts:
+    sentry:
+      - name: kube-api-access
+        mountPath: /var/run/secrets/kubernetes.io/serviceaccount
+        readOnly: true
+  extraVolumes:
+    sentry:
+      - name: kube-api-access
+        secret:
+          secretName: dapr-sentry-token
+
+# D3E token (replace with your actual token)
+diagrid:
+  token: "YOUR_D3E_TOKEN_HERE"
+
+dapr_operator:
+  enabled: false
+
+dapr_sidecar_injector:
+  enabled: false
+
+dapr_sentry:
+  mode: "standalone"
+  injectDaprSystemConfig: true
+#  extraEnvVars:
+#    - name: KUBERNETES_SERVICE_HOST
+#      value: kubernetes.default.svc.cluster.local
+#    - name: KUBERNETES_SERVICE_PORT
+#      value: "443"
+
+dapr_config:
+  dapr_config_chart_included: false
+
+namespace: "d3e-sample" 

--- a/d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml
+++ b/d3e-configs/standalone-no-crds-automount-sentry-disabled.yaml
@@ -4,7 +4,7 @@
 # This is the configuration currently used in the Makefile
 
 global:
-  tag: "1.15.5"
+  tag: "1.15.6-d3e.1"
   mtls:
     enabled: true
   actors:
@@ -20,7 +20,6 @@ global:
       enabled: false
     crds:
       enabled: false
-
     createTokenReviewerRole: false
     createTokenReviewerRoleBinding: false
     sentry:

--- a/d3e-configs/standalone-no-crds.yaml
+++ b/d3e-configs/standalone-no-crds.yaml
@@ -29,12 +29,6 @@ dapr_operator:
 dapr_sidecar_injector:
   enabled: false
 
-dapr_placement:
-  mode: "standalone"
-
-dapr_scheduler:
-  mode: "standalone"
-
 dapr_sentry:
   mode: "standalone"
   injectDaprSystemConfig: true

--- a/d3e-configs/standalone-no-crds.yaml
+++ b/d3e-configs/standalone-no-crds.yaml
@@ -4,7 +4,7 @@
 # This is the configuration currently used in the Makefile
 
 global:
-  tag: "1.15.6"
+  tag: "1.15.6-d3e.1"
   mtls:
     enabled: true
   actors:

--- a/d3e-configs/standalone-no-crds.yaml
+++ b/d3e-configs/standalone-no-crds.yaml
@@ -4,7 +4,7 @@
 # This is the configuration currently used in the Makefile
 
 global:
-  tag: "1.15.5"
+  tag: "1.15.6"
   mtls:
     enabled: true
   actors:

--- a/sample-configs/d3e-with-crds-no-cluster-roles.yaml
+++ b/sample-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/sample-configs/d3e-with-crds-no-cluster-roles.yaml
+++ b/sample-configs/d3e-with-crds-no-cluster-roles.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.5"
+    tag: "1.15.6"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/sample-configs/minimal.yaml
+++ b/sample-configs/minimal.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/sample-configs/minimal.yaml
+++ b/sample-configs/minimal.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.5"
+    tag: "1.15.6"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/sample-configs/standalone-no-crds.yaml
+++ b/sample-configs/standalone-no-crds.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/sample-configs/standalone-no-crds.yaml
+++ b/sample-configs/standalone-no-crds.yaml
@@ -15,7 +15,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.5"
+    tag: "1.15.6"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.6"
+    tag: "1.15.6-d3e.1"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 

--- a/values.yaml
+++ b/values.yaml
@@ -27,7 +27,7 @@ serviceAccount:
 
 dapr:
   image:
-    tag: "1.15.5"
+    tag: "1.15.6"
     pullPolicy: IfNotPresent
   controlPlaneNamespace: "d3e-sample" # default is Release.Namespace (ie dapr-system)
 


### PR DESCRIPTION
- added `standalone-no-crds-automount-sentry-disabled.yaml` example for automount=false with dapr sentry
- removed dead scheduler and placement config in existing examples where they had been disabled
- bumped versions to 1.15.6